### PR TITLE
Only build main branches in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ group: deprecated-2017Q3
 os: linux
 language: generic
 
+# Only build main branches
+branches:
+  only:
+  - master
+  - develop
+
 services:
   - docker
 


### PR DESCRIPTION
~Please do not merge. Testing how Travis behaves with branch safelist and pull requests.~

**UPDATE:** This PR disables building of non-develop/master branches. This is needed because for Evolution, we do development in a private repo and PRs are originating from branches in this repo. Travis will by default build such PRs twice, once for the branch-push and once for the PR.