### PR TITLE
Strip debug information from binaries before adding these to Docker

### DIFF
--- a/docker/build-docker.sh
+++ b/docker/build-docker.sh
@@ -12,5 +12,8 @@ rm docker/bin/*
 cp $BUILD_DIR/src/dashd docker/bin/
 cp $BUILD_DIR/src/dash-cli docker/bin/
 cp $BUILD_DIR/src/dash-tx docker/bin/
+strip docker/bin/dashd
+strip docker/bin/dash-cli
+strip docker/bin/dash-tx
 
 docker build -t $DOCKER_IMAGE:$DOCKER_TAG -f docker/Dockerfile docker


### PR DESCRIPTION
This is mostly useful when building locally and having debug informations enabled