### PR TITLE
Push to develop tag instead of latest in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ env:
     - DOCKER_BUILD=false
     - DOCKER_REPO=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
     - DOCKER_IMAGE=dashevo/dashcore
+    - DOCKER_TAG=develop
 
   matrix:
 # ARM


### PR DESCRIPTION
When merging the public dashpay repo into dashevo, I made it push to the latest tag by accident. Make it push to develop instead.